### PR TITLE
make IPC path configurable

### DIFF
--- a/discord-emacs.el
+++ b/discord-emacs.el
@@ -9,6 +9,21 @@
 
 ;;; Code:
 
+(defgroup discord-emacs nil
+  "Discord ipc for emacs"
+  :prefix "discord-emacs-"
+  :group 'external)
+
+(defcustom discord-emacs-ipc-dir (format "/run/user/%i/" (user-uid))
+  "Directory where discord IPC socket lives."
+  :group 'discord-emacs
+  :type 'string)
+
+(defcustom discord-emacs-ipc-name "discord-ipc-0"
+  "Discord IPC socket name."
+  :group 'discord-emacs
+  :type 'string)
+
 (defvar discord-emacs--+handshake+ 0)
 (defvar discord-emacs--+frame+ 1)
 (defvar discord-emacs--+close+ 2)
@@ -30,7 +45,7 @@
 
 (defun discord-emacs--get-ipc-url ()
   "Get the socket address to make the ipc connection on."
-  (format "/run/user/%i/discord-ipc-0" (user-uid)))
+  (concat (file-name-as-directory discord-emacs-ipc-dir) discord-emacs-ipc-name))
 
 (defun discord-emacs--make-ipc-connection ()
   "Make a ipc socket connection."


### PR DESCRIPTION
Hi! 
On my gentoo with **discord-bin** package discord IPC path is `/tmp/discord-ipc-0`.
I made this path configurable via emacs' customize interface.
Here is example from my config with use-package:
```emacs-lisp
(use-package discord-emacs
  :ensure nil
  :quelpa
  (discord-emacs :repo "pkulev/discord-emacs.el"
                 :branch "make-ipc-path-configurable"
                 :fetcher github :upgrade t)
  :custom
  (discord-emacs-ipc-dir "/tmp")
  :config
  (discord-emacs-run "384815451978334208"))
```

And now we have nice customize-group section
![image](https://user-images.githubusercontent.com/1115916/77287953-d54c1600-6ce7-11ea-8db4-2c9f1f02c891.png)


Signed-off-by: Pavel Kulyov <kulyov.pavel@gmail.com>