### PR TITLE
Fix typo in process name in stop function

### DIFF
--- a/discord-emacs.el
+++ b/discord-emacs.el
@@ -152,7 +152,7 @@
       (discord-emacs--ipc-connect client-id))))
 
 (defun discord-emacs-stop ()
-  (when-let ((process (get-process "discord-ipc-progress")))
+  (when-let ((process (get-process "discord-ipc-process")))
     (delete-process process)
     (setq discord-emacs--started nil)))
 


### PR DESCRIPTION
`discord-emacs-stop` wasn't working on my machine, looks like the process name was just misspelled